### PR TITLE
Write Impact Recipe Changes

### DIFF
--- a/recipes/write_impact_check.rcp
+++ b/recipes/write_impact_check.rcp
@@ -29,63 +29,63 @@
 # ISSUE-REVIEW: This could be made to work w/raw_disk if its ever important
 unless( $cmd_line->raw_disk )
 {
-  my $desc_prefix = "Targeted Test Write Impact";
+    my $desc_prefix = "Targeted Test Write Impact";
 
-  foreach my $block_size ( qw( 4K 8K 64K ) )
-  {
-    my %workload = (
-      write_percentage    => 0,
-      access_pattern      => "random",
-      block_size          => $block_size,
-      queue_depth         => 1,
-      warmup_time         => 60,
-      run_time            => 3600
-    );
-
-    my $desc = "$desc_prefix $block_size Random";
-
-    # Run the workload once unmolested as a baseline.
-    my %baseline =
-        test( %workload, description => "$desc Baseline" );
-
-    my $read_tput_KBps = $baseline{'MB/sec Total'} * 1000;
-
-    # Run again, this time with an aggressor process injecting
-    # writes in the background.  The aggressor is rate-limited
-    # to a fraction of the baseline read throughput.
-    foreach my $write_pct ( qw( 5 10 ) )
+    foreach my $block_size ( qw( 4K 8K 64K ) )
     {
-      my $write_tput_KBps =
-          int ( ( $write_pct / 100 ) * $read_tput_KBps );
+        my %workload = (
+            write_percentage    => 0,
+            access_pattern      => "random",
+            block_size          => $block_size,
+            queue_depth         => 1,
+            warmup_time         => 60,
+            run_time            => 3600
+        );
 
-      my $bg_desc = "$write_pct% Injected Writes";
+        my $desc = "$desc_prefix $block_size Random";
 
-      my $cmd = "write_forever.cmd ";
+        # Run the workload once unmolested as a baseline.
+        my %baseline =
+            test( %workload, description => "$desc Baseline" );
 
-      $cmd .= "-b256K ";
-      $cmd .= "-r " if $write_pct == 5;
-      $cmd .= "-g$write_tput_KBps "; # Rate limit
-      $cmd .= $target->file_name;
+        my $read_tput_KBps = $baseline{'MB/sec Total'} * 1000;
 
-      # We must do our own purge/initialize, so we can "sneak"
-      # the bg_exec in between these steps and the actual test.
-      # If we didn't do this, the purge would occur after the
-      # bg_exec, effectively destroying the target volume and
-      # causing the backgrounded process to die with an error.
+        # Run again, this time with an aggressor process injecting
+        # writes in the background.  The aggressor is rate-limited
+        # to a fraction of the baseline read throughput.
+        foreach my $write_pct ( qw( 5 10 ) )
+        {
+            my $write_tput_KBps =
+                int ( ( $write_pct / 100 ) * $read_tput_KBps );
 
-      purge();
-      initialize();
-      bg_exec(
-        description => $bg_desc,
-        command => $cmd,
-      );
-      test(
-        %workload,
-        description => "$desc $bg_desc",
-        purge => 0,
-        initialize => 0,
-      );
-      bg_killall();
+            my $bg_desc = "$write_pct% Injected Writes";
+
+            my $cmd = "write_forever.cmd ";
+
+            $cmd .= "-b256K ";
+            $cmd .= "-r " if $write_pct == 5;
+            $cmd .= "-g$write_tput_KBps "; # Rate limit
+            $cmd .= $target->file_name;
+
+            # We must do our own purge/initialize, so we can "sneak"
+            # the bg_exec in between these steps and the actual test.
+            # If we didn't do this, the purge would occur after the
+            # bg_exec, effectively destroying the target volume and
+            # causing the backgrounded process to die with an error.
+
+            purge();
+                initialize();
+                bg_exec(
+                description => $bg_desc,
+                command => $cmd,
+            );
+            test(
+                %workload,
+                description => "$desc $bg_desc",
+                purge => 0,
+                initialize => 0,
+            );
+            bg_killall();
+        }
     }
-  }
 }

--- a/recipes/write_impact_check.rcp
+++ b/recipes/write_impact_check.rcp
@@ -33,62 +33,59 @@ unless( $cmd_line->raw_disk )
 
     foreach my $block_size ( qw( 4K 8K 64K ) )
     {
-        foreach my $access_pattern ( qw( Random Sequential ) )
-        {
-            my %workload = (
-                write_percentage    => 0, 
-                access_pattern      => lc( $access_pattern ),
-                block_size          => $block_size,
-                queue_depth         => 4,
-                warmup_time         => 60,
-                run_time            => 3600
-            ); 
-           
-            my $desc = "$desc_prefix $block_size $access_pattern";
+		my %workload = (
+			write_percentage    => 0, 
+			access_pattern      => "random",
+			block_size          => $block_size,
+			queue_depth         => 1,
+			warmup_time         => 60,
+			run_time            => 3600
+		); 
+	   
+		my $desc = "$desc_prefix $block_size Random";
 
-            # Run the workload once unmolested as a baseline.
-            my %baseline =
-                test( %workload, description => "$desc Baseline" );
-            
-            my $read_tput_KBps = $baseline{'MB/sec Total'} * 1000;
+		# Run the workload once unmolested as a baseline.
+		my %baseline =
+			test( %workload, description => "$desc Baseline" );
+		
+		my $read_tput_KBps = $baseline{'MB/sec Total'} * 1000;
 
-            # Run again, this time with an aggressor process injecting
-            # writes in the background.  The aggressor is rate-limited
-            # to a fraction of the baseline read throughput.
-            foreach my $write_pct ( qw( 5 10 ) )
-            {
-                my $write_tput_KBps =
-                    int ( ( $write_pct / 100 ) * $read_tput_KBps );
+		# Run again, this time with an aggressor process injecting
+		# writes in the background.  The aggressor is rate-limited
+		# to a fraction of the baseline read throughput.
+		foreach my $write_pct ( qw( 5 10 ) )
+		{
+			my $write_tput_KBps =
+				int ( ( $write_pct / 100 ) * $read_tput_KBps );
 
-                my $bg_desc = "$write_pct% Injected Writes";
+			my $bg_desc = "$write_pct% Injected Writes";
 
-                my $cmd = "write_forever.cmd ";
+			my $cmd = "write_forever.cmd ";
 
-                $cmd .= "-b$block_size ";
-                $cmd .= "-r " if $access_pattern =~ /random/i;
-                $cmd .= "-g$write_tput_KBps "; # Rate limit
-                $cmd .= $target->file_name;
+			$cmd .= "-b256K ";
+			$cmd .= "-r " if $write_pct == 5;
+			$cmd .= "-g$write_tput_KBps "; # Rate limit
+			$cmd .= $target->file_name;
 
-                # We must do our own purge/initialize, so we can "sneak"
-                # the bg_exec in between these steps and the actual test.
-                # If we didn't do this, the purge would occur after the
-                # bg_exec, effectively destroying the target volume and
-                # causing the backgrounded process to die with an error.
-
-                purge();
-                initialize();
-                bg_exec(
-                    description => $bg_desc,
-                    command => $cmd,
-                );
-                test( 
-                    %workload,
-                    description => "$desc $bg_desc",
-                    purge => 0,
-                    initialize => 0,
-                );
-                bg_killall();
-            }
-        }
+			# We must do our own purge/initialize, so we can "sneak"
+			# the bg_exec in between these steps and the actual test.
+			# If we didn't do this, the purge would occur after the
+			# bg_exec, effectively destroying the target volume and
+			# causing the backgrounded process to die with an error.
+			
+			purge();
+			initialize();
+			bg_exec(
+				description => $bg_desc,
+				command => $cmd,
+			);
+			test( 
+				%workload,
+				description => "$desc $bg_desc",
+				purge => 0,
+				initialize => 0,
+			);
+			bg_killall();
+		}
     }
 }

--- a/recipes/write_impact_check.rcp
+++ b/recipes/write_impact_check.rcp
@@ -58,10 +58,10 @@ unless( $cmd_line->raw_disk )
         # Run again, this time with an aggressor process injecting
         # writes in the background.  The aggressor is rate-limited
         # to a fraction of the baseline read throughput.
-        foreach my $write_workload ( @write_workloads )
+        foreach my $write_workload ( $write_workloads )
         {
 
-            my $($write_pattern, $write_pct) = @$write_workload;
+            my ($write_pattern, $write_pct) = $write_workload;
 
             my $write_tput_KBps =
                 int ( ( $write_pct / 100 ) * $read_tput_KBps );

--- a/recipes/write_impact_check.rcp
+++ b/recipes/write_impact_check.rcp
@@ -50,11 +50,19 @@ unless( $cmd_line->raw_disk )
 
         my $read_tput_KBps = $baseline{'MB/sec Total'} * 1000;
 
+        my $write_workloads = {
+            ["Random", 5],
+            ["Sequential", 10]
+        };
+
         # Run again, this time with an aggressor process injecting
         # writes in the background.  The aggressor is rate-limited
         # to a fraction of the baseline read throughput.
-        foreach my $write_pct ( qw( 5 10 ) )
+        foreach my $write_workload ( @write_workloads )
         {
+
+            my $($write_pattern, $write_pct) = @$write_workload;
+
             my $write_tput_KBps =
                 int ( ( $write_pct / 100 ) * $read_tput_KBps );
 
@@ -63,7 +71,7 @@ unless( $cmd_line->raw_disk )
             my $cmd = "write_forever.cmd ";
 
             $cmd .= "-b256K ";
-            $cmd .= "-r " if $write_pct == 5;
+            $cmd .= "-r " if $write_pattern == "Random";
             $cmd .= "-g$write_tput_KBps "; # Rate limit
             $cmd .= $target->file_name;
 

--- a/recipes/write_impact_check.rcp
+++ b/recipes/write_impact_check.rcp
@@ -4,7 +4,7 @@
 #
 # Copyright (c) Microsoft Corporation
 #
-# All rights reserved. 
+# All rights reserved.
 #
 # MIT License
 #
@@ -29,63 +29,63 @@
 # ISSUE-REVIEW: This could be made to work w/raw_disk if its ever important
 unless( $cmd_line->raw_disk )
 {
-    my $desc_prefix = "Targeted Test Write Impact";
+  my $desc_prefix = "Targeted Test Write Impact";
 
-    foreach my $block_size ( qw( 4K 8K 64K ) )
+  foreach my $block_size ( qw( 4K 8K 64K ) )
+  {
+    my %workload = (
+      write_percentage    => 0,
+      access_pattern      => "random",
+      block_size          => $block_size,
+      queue_depth         => 1,
+      warmup_time         => 60,
+      run_time            => 3600
+    );
+
+    my $desc = "$desc_prefix $block_size Random";
+
+    # Run the workload once unmolested as a baseline.
+    my %baseline =
+        test( %workload, description => "$desc Baseline" );
+
+    my $read_tput_KBps = $baseline{'MB/sec Total'} * 1000;
+
+    # Run again, this time with an aggressor process injecting
+    # writes in the background.  The aggressor is rate-limited
+    # to a fraction of the baseline read throughput.
+    foreach my $write_pct ( qw( 5 10 ) )
     {
-		my %workload = (
-			write_percentage    => 0, 
-			access_pattern      => "random",
-			block_size          => $block_size,
-			queue_depth         => 1,
-			warmup_time         => 60,
-			run_time            => 3600
-		); 
-	   
-		my $desc = "$desc_prefix $block_size Random";
+      my $write_tput_KBps =
+          int ( ( $write_pct / 100 ) * $read_tput_KBps );
 
-		# Run the workload once unmolested as a baseline.
-		my %baseline =
-			test( %workload, description => "$desc Baseline" );
-		
-		my $read_tput_KBps = $baseline{'MB/sec Total'} * 1000;
+      my $bg_desc = "$write_pct% Injected Writes";
 
-		# Run again, this time with an aggressor process injecting
-		# writes in the background.  The aggressor is rate-limited
-		# to a fraction of the baseline read throughput.
-		foreach my $write_pct ( qw( 5 10 ) )
-		{
-			my $write_tput_KBps =
-				int ( ( $write_pct / 100 ) * $read_tput_KBps );
+      my $cmd = "write_forever.cmd ";
 
-			my $bg_desc = "$write_pct% Injected Writes";
+      $cmd .= "-b256K ";
+      $cmd .= "-r " if $write_pct == 5;
+      $cmd .= "-g$write_tput_KBps "; # Rate limit
+      $cmd .= $target->file_name;
 
-			my $cmd = "write_forever.cmd ";
+      # We must do our own purge/initialize, so we can "sneak"
+      # the bg_exec in between these steps and the actual test.
+      # If we didn't do this, the purge would occur after the
+      # bg_exec, effectively destroying the target volume and
+      # causing the backgrounded process to die with an error.
 
-			$cmd .= "-b256K ";
-			$cmd .= "-r " if $write_pct == 5;
-			$cmd .= "-g$write_tput_KBps "; # Rate limit
-			$cmd .= $target->file_name;
-
-			# We must do our own purge/initialize, so we can "sneak"
-			# the bg_exec in between these steps and the actual test.
-			# If we didn't do this, the purge would occur after the
-			# bg_exec, effectively destroying the target volume and
-			# causing the backgrounded process to die with an error.
-			
-			purge();
-			initialize();
-			bg_exec(
-				description => $bg_desc,
-				command => $cmd,
-			);
-			test( 
-				%workload,
-				description => "$desc $bg_desc",
-				purge => 0,
-				initialize => 0,
-			);
-			bg_killall();
-		}
+      purge();
+      initialize();
+      bg_exec(
+        description => $bg_desc,
+        command => $cmd,
+      );
+      test(
+        %workload,
+        description => "$desc $bg_desc",
+        purge => 0,
+        initialize => 0,
+      );
+      bg_killall();
     }
+  }
 }


### PR DESCRIPTION
Seagate is proposing the following changes to "Write_Impact_Check.rcp" in order to comply with the public release of the OCS Specification 2.1.

The changes modify the following parameters:

1. All reads are random 4K.

2. All injected writes are 256K.

3. The writes during the 5% Injected sequence are random.

4. The writes during the 10% Injected sequence are sequential.

5. Various cosmetic changes.